### PR TITLE
Added functions to run QAOA with degenerateADAPT

### DIFF
--- a/src/degenerateADAPT/DegenerateADAPT.jl
+++ b/src/degenerateADAPT/DegenerateADAPT.jl
@@ -35,7 +35,7 @@ function ADAPT.adapt!(
     end
 
     # MAKE SELECTION
-    largest_score = maximum(scores); indices_of_largest_scores = findall(a->a==largest_score, scores) 
+    largest_score = maximum(scores); indices_of_largest_scores = findall(a->abs(a-largest_score)<=1e-3, scores) 
 #     println("gradient degeneracy: ",length(indices_of_largest_scores))
 #     println("operators with degenerate max. gradients: ",pool[indices_of_largest_scores])
     selected_index = rand(indices_of_largest_scores)    

--- a/src/qaoa/QAOA.jl
+++ b/src/qaoa/QAOA.jl
@@ -157,3 +157,16 @@ function ADAPT.calculate_score(
     return abs(ADAPT.Basics.MyPauliOperators.measure_commutator(
             generator, observable, state))
 end
+
+function ADAPT.calculate_score(
+    ansatz::QAOAAnsatz,
+    ::ADAPT.Degenerate_ADAPT.DegenerateADAPT,
+    generator::AnyPauli,
+    observable::AnyPauli,
+    reference::ADAPT.QuantumState,
+)
+    state = ADAPT.evolve_state(ansatz, reference)
+    ADAPT.evolve_state!(ansatz.observable, ansatz.γ0, state)
+    return abs(ADAPT.Basics.MyPauliOperators.measure_commutator(
+            generator, observable, state))
+end


### PR DESCRIPTION
Added a `calculate_score` function in QAOA.jl (in the form QAOA is set up as of now, the scores for degenerateADAPT aren't being calculated correctly without this addition).
Significantly softened the degeneracy criteria in degenerateADAPT to include gradients that differ by > system accuracy